### PR TITLE
Fix/ros2 build param issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,4 @@ The default parameters should work on the KITTI dataset.
 ### Other
 
 - **n_threads**  Number of threads to use.
-- **latch**  Latch output point clouds in ROS node. 
 - **visualize** Visualize the segmentation result. **ONLY FOR DEBUGGING.** Do not set true during online operation.

--- a/linefit_ground_segmentation/include/ground_segmentation/ground_segmentation.h
+++ b/linefit_ground_segmentation/include/ground_segmentation/ground_segmentation.h
@@ -55,6 +55,12 @@ struct GroundSegmentationParams {
   double line_search_angle;
   // Number of threads.
   int n_threads;
+  // Minimum point distance.
+  double r_min;
+  // Maximum point distance.
+  double r_max;
+  // Maximum error of a point during line fit.
+  double max_fit_error;
 };
 
 typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;

--- a/linefit_ground_segmentation_ros/launch/segmentation_params.yaml
+++ b/linefit_ground_segmentation_ros/launch/segmentation_params.yaml
@@ -20,7 +20,6 @@ ground_segmentation:
 
     gravity_aligned_frame: ""   # Frame which has its z axis aligned with gravity. (Sensor frame if empty.)
 
-    latch: false                # latch output topics or not
     visualize: false            # visualize segmentation result - USE ONLY FOR DEBUGGING
 
     input_topic: "livox/lidar/pointcloud"

--- a/linefit_ground_segmentation_ros/src/ground_segmentation_node.cc
+++ b/linefit_ground_segmentation_ros/src/ground_segmentation_node.cc
@@ -4,7 +4,7 @@
 #include <pcl/common/transforms.h>
 #include <pcl/io/ply_io.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <pcl_ros/point_cloud.h>
+// #include <pcl_ros/point_cloud.hpp>
 #include <rclcpp/qos.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>

--- a/linefit_ground_segmentation_ros/src/ground_segmentation_node.cc
+++ b/linefit_ground_segmentation_ros/src/ground_segmentation_node.cc
@@ -52,6 +52,10 @@ SegmentationNode::SegmentationNode(const rclcpp::NodeOptions &node_options)
   params_.line_search_angle =
       this->declare_parameter("line_search_angle", params_.line_search_angle);
   params_.n_threads = this->declare_parameter("n_threads", params_.n_threads);
+  params_.r_min = this->declare_parameter("r_min", params_.r_min);
+  params_.r_max = this->declare_parameter("r_max", params_.r_max);
+  params_.max_fit_error =
+      this->declare_parameter("max_fit_error", params_.max_fit_error);
   // Params that need to be squared.
   double r_min, r_max, max_fit_error;
   if (this->get_parameter("r_min", r_min)) {
@@ -81,6 +85,8 @@ SegmentationNode::SegmentationNode(const rclcpp::NodeOptions &node_options)
   tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
   RCLCPP_INFO(this->get_logger(), "Segmentation node initialized");
+  RCLCPP_INFO(this->get_logger(), "params_.r_min_square: %f",
+              params_.r_min_square);
 }
 
 void SegmentationNode::scanCallback(

--- a/linefit_ground_segmentation_ros/src/ground_segmentation_test_node.cc
+++ b/linefit_ground_segmentation_ros/src/ground_segmentation_test_node.cc
@@ -1,5 +1,5 @@
 #include <pcl/io/ply_io.h>
-#include <pcl_ros/point_cloud.h>
+// #include <pcl_ros/point_cloud.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 

--- a/linefit_ground_segmentation_ros/src/ground_segmentation_test_node.cc
+++ b/linefit_ground_segmentation_ros/src/ground_segmentation_test_node.cc
@@ -34,6 +34,10 @@ int main(int argc, char **argv) {
     params.line_search_angle =
         node->declare_parameter("line_search_angle", params.line_search_angle);
     params.n_threads = node->declare_parameter("n_threads", params.n_threads);
+    params.r_min = node->declare_parameter("r_min", params.r_min);
+    params.r_max = node->declare_parameter("r_max", params.r_max);
+    params.max_fit_error =
+        node->declare_parameter("max_fit_error", params.max_fit_error);
         // Params that need to be squared.
     double r_min, r_max, max_fit_error;
     if (node->get_parameter("r_min", r_min)) {


### PR DESCRIPTION
## PR Type
<!--
Please select the type of changes you're introducing to the codebase:
-->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Overview
- Fixes problems with `colcon build` not going through.
- Fixes problems with access to parameters.
- Delete unused parameter.

## Detail
- In pcl_ros for ROS 2, `pcl_ros/point_cloud.h` is incorrect and the correct name is `pcl_ros/point_cloud.hpp`. However, as mentioned below, `pcl_ros/point_cloud.hpp` is not yet implemented and the build will not pass. For this issue, only commenting it out improved it and did not interfere with its functioning.
  https://github.com/ros-perception/perception_pcl/issues/225#issuecomment-1543540421
- As mentioned below, ROS 2 Dashing or later requires that a declaration is made before parameters can be accessed. Therefore, I added declarations for `r_min`, `r_max` and `max_fit_error`, which had not been declared.
  https://docs.ros.org/en/galactic/Releases/Release-Dashing-Diademata.html#declaring-parameters:~:text=As%20of%20Dashing%2C%20parameters%20now%20need%20to%20be%20declared%20before%20being%20accessed%20or%20set. 
- The parameter `latch` has been removed as it is not used in this code.
## Test
- [x] I have tested this change with gazebo

## Attention
- マージしてもブランチは削除しないよう注意お願いします。